### PR TITLE
Added support for postgresql 9.6 and pgsql-postal which will compile

### DIFF
--- a/9.6/Dockerfile
+++ b/9.6/Dockerfile
@@ -42,19 +42,19 @@ RUN cd /usr/local/libpostal && \
 ## PGSQL-POSTAL -- Bindings
 # Download bindings - pgsql-postal - from source to /usr/lib/pgsql-postal
 RUN cd /usr/lib && \
-	git clone https://github.com/pramsey/pgsql-postal.git
+	git clone https://github.com/openvenues/pgsql-postal.git
 
 # Download dependencies
-RUN apt-get install -y postgresql-server-dev-9.5
+RUN apt-get install -y postgresql-server-dev-9.6
 
-RUN cd /usr/lib/pgsql-postal && \
+RUN cd /usr/lib/pgsql-postal && git checkout 1.0 &&\
 	make && \
 	make install
 
 ## Attempting this with appropriate environment cleanup. We'll call this "security".
 ## But it will be insufficient. 
 RUN apt-get remove -y \
-	postgresql-server-dev-9.5 \
+	postgresql-server-dev-9.6 \
 	pkg-config \
 	libtool \
 	automake \


### PR DESCRIPTION
Updated this Dockerfile to use [this fork](https://github.com/openvenues/pgsql-postal/tree/1.0) until  the [original project](https://github.com/pramsey/pgsql-postal) accepts [pull request 10](https://github.com/pramsey/pgsql-postal/pull/10).

This should be postgres compatible, for use with [Dokku](https://github.com/dokku/dokku), per [this issue](https://github.com/dokku/dokku-postgres/issues/52).